### PR TITLE
send invite code, display invite code, leave household, cleaned up logic

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -47,6 +47,7 @@ export interface Database {
           name: string;
           country: string;
           zip_code: string;
+          join_code: string;
           latitude?: number;
           longitude?: number;
           created_at: string;
@@ -57,6 +58,7 @@ export interface Database {
           name: string;
           country: string;
           zip_code: string;
+          join_code?: string;
           latitude?: number;
           longitude?: number;
           created_at?: string;
@@ -66,6 +68,7 @@ export interface Database {
           name?: string;
           country?: string;
           zip_code?: string;
+          join_code?: string;
           latitude?: number;
           longitude?: number;
           updated_at?: string;


### PR DESCRIPTION
- Implement invite functionality to share household join codes via the Share API.
- Add option for users to leave their current household with confirmation alerts.
- Display household join code in the profile view for easier access.
- Update database schema to include join codes for households.
- Refactor member account display logic and clean up unused code.